### PR TITLE
fix: Constraint on tree adoption

### DIFF
--- a/supabase/migrations/20221110153556_constraint_on_trees_adopted.sql
+++ b/supabase/migrations/20221110153556_constraint_on_trees_adopted.sql
@@ -1,0 +1,7 @@
+CREATE UNIQUE INDEX trees_adopted_tree_id_uuid_key ON public.trees_adopted USING btree (tree_id, uuid);
+
+CREATE INDEX trees_adopted_uuid ON public.trees_adopted USING btree (uuid);
+
+alter table "public"."trees_adopted" add constraint "trees_adopted_tree_id_uuid_key" UNIQUE using index "trees_adopted_tree_id_uuid_key";
+
+


### PR DESCRIPTION
This PR fixes a missing constraint for unique tree id user id on adoption